### PR TITLE
Fixed bug that causes some magnet links to fail opening

### DIFF
--- a/Classes/TSTorrentFunctions.m
+++ b/Classes/TSTorrentFunctions.m
@@ -99,8 +99,7 @@
         if ([url rangeOfString:@"magnet:"].location != NSNotFound) {
             
             // Just open it
-            [[NSWorkspace sharedWorkspace] openURL:
-             [NSURL URLWithString:[url stringByReplacingOccurrencesOfString:@" " withString:@"%20"]]];
+            [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:[url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]];
             
 #if HELPER_APP
             if([TSUserDefaults getBoolFromKey:@"GrowlOnNewEpisode" withDefault:1]) {


### PR DESCRIPTION
Found the bug that was causing some magnet link to fail opening.
URL escaping in TSTorrentFunctions.m `downloadEpisode: ofShow:` (line 102) should be done as:

``` objc
[NSURL URLWithString:[url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]
```

instead of

``` objc
[url stringByReplacingOccurencesOfString:@" " withString:@"%20"]
```

Replacing whitespaces with "%20" could result in a malformed string not accepted by `URLWithString:` (in which case the return value is nil and clearly `openURL:nil` ends up in doing nothing).

Thanks for all your work btw :)
