### PR TITLE
[Improvement] Keep torrent app in BG when opening magnet links.

### DIFF
--- a/Classes/TSTorrentFunctions.m
+++ b/Classes/TSTorrentFunctions.m
@@ -99,8 +99,10 @@
         if ([url rangeOfString:@"magnet:"].location != NSNotFound) {
             
             // Just open it
-            [[NSWorkspace sharedWorkspace] openURL:
-             [NSURL URLWithString:[url stringByReplacingOccurrencesOfString:@" " withString:@"%20"]]];
+            // Open magnet links without bring app that handles them to the foreground
+            NSArray* urls = [NSArray arrayWithObject:[url stringByReplacingOccurrencesOfString:@" " withString:@"%20"]];
+            [[NSWorkspace sharedWorkspace] openURLs:urls withAppBundleIdentifier:nil 
+                options:NSWorkspaceLaunchWithoutActivation additionalEventParamDescriptor:nil launchIdentifiers:nil];
             
 #if HELPER_APP
             if([TSUserDefaults getBoolFromKey:@"GrowlOnNewEpisode" withDefault:1]) {


### PR DESCRIPTION
> **Disclosure:** I _am_ a developer, but I have very limited experience with Objective-C.

The problem: when TVShows opens magnet links, it is handled by whatever application is set to handle magnet links. In my case, this app is Transmission. Despite whatever settings I use in Transmission, when that magnet link is opened, Transmission is brought to the front. This is especially undesirable when--like me--people use the same computer to run Transmission as their media center. This means as we're peacefully minding our own business, watching--let's say Plex--and TVShows opens a magnet link and Transmission pops up over our show!

I thought it was Transmission's fault, but it seems to be the way OS X handles opening URLs like magnet links. By default, it brings the app to the foreground. I found learned about this thanks to the user diamondsw on this thread: https://forums.plex.tv/index.php/topic/48190-transmission-keeps-popping-into-foreground-over-plex/

So I figured I'd be a good OSS contributor and fix this myself on TVShows (even tho this project appears to be as dead as it gets...?). As I mentioned before, tho... I'm no Obj-C dev. After much searching, I found out how to implement diamondsw's fix (see: http://zachwaugh.me/posts/opening-links-in-background-with-cocoa/), and apply it in this PR.

I believe this only applies to magnet links and not to downloading torrent files and having Transmission watch the Downloads directory.

Also, I use Tranmission as an example, but I am pretty sure any app that handles magnet links will suffer from this issue.
